### PR TITLE
Allow word_filter to be disabled for en

### DIFF
--- a/sphinx/search/en.py
+++ b/sphinx/search/en.py
@@ -224,7 +224,15 @@ class SearchEnglish(SearchLanguage):
     def init(self, options):
         # type: (Dict) -> None
         self.stemmer = get_stemmer()
+        self.disable_filter = options.get("disable_filter", False)
 
     def stem(self, word):
         # type: (unicode) -> unicode
         return self.stemmer.stem(word.lower())
+
+    def word_filter(self, word):
+        # type: (unicode) -> bool
+        if self.disable_filter:
+            return True
+        else:
+            return super(SearchEnglish, self).word_filter(word)


### PR DESCRIPTION
The reason that SD-WAN was not searchable is that, during compilation, sphinx first splits this keyword to two words, SD and WAN, and then applies the Porter Stemming Algorithm (https://tartarus.org/martin/PorterStemmer/) and transform them to `sd` and `wan`. The stemmed keywords are supposingly to show up as search keywords. However, sphinx also implements a `word_filter` function, that will filter away `sd` during the compilation. Even more weirdly, the javascript counterpart does not include this filter process. As a result, javascript tries to search a doc with both `sd` and `wan`, yet the compiled index only contains `wan`.

To fix this, I have added an option for the builder to disable this filter during compilation.